### PR TITLE
Add train split creation

### DIFF
--- a/scripts/nlp/en_spellmapper/dataset_preparation/build_training_data.sh
+++ b/scripts/nlp/en_spellmapper/dataset_preparation/build_training_data.sh
@@ -232,7 +232,9 @@ python ${NEMO_COMPATIBLE_PATH}/scripts/nlp/en_spellmapper/dataset_preparation/ma
 ## t _ v _ o r _ e y e _ o n _ t h e _ f i r s t _ o f _ f e b r u a r y _ o f _ t h a t _ y e a r _ s _ b _ c _ c e l e b r a t e d       t v r _ t u s c a n;t h e _ f i r s t _ e d e n;w s p c;s b c _ p u b l i s h i n g _ b u i l d i n g;t v r _ g r a n t u r a;t v r i;s b c;s o a e b _ t a i;d u y a r;f i n t h e n     6 7     CUSTOM 0 10;CUSTOM 49 54
 ## d i s t r i c t _ o f _ a f g h a n i s t a n   d i s t r i c t _ o f _ p r i s t i n a;f e n i _ d i s t r i c t;d i s t r i c t _ o f _ l o u i s i a n a;m o r g a n _ s t a n l e y;f l a g _ o f _ a f g h a n i s t a n;u n a _ d i s t r i c t;z i r c _ d i s t r i c t;f i n n _ f u g l e s t a d;p h l o _ f i n i s t e r;g u s t a f _ a u l e n     0
 
-tail -n 20000 all.tsv > test.tsv
+N_TEST_EXAMPLES=20000
+tail -n ${N_TEST_EXAMPLES} all.tsv > test.tsv
+head -n -${N_TEST_EXAMPLES} all.tsv > train.tsv
 ## take all other lines to train.tsv
 
 ## To generate files config.json, label_map.txt, semiotic_classes.txt, run generate_configs.sh


### PR DESCRIPTION
This PR fixes the following error:

```
raise ValueError("Cannot find file: " + input_filename)
ValueError: Cannot find file: /nemo_compatible/scripts/nlp/en_spellmapper/dataset_preparation/train.tsv
```

which occurs when runnnig 

https://github.com/NVIDIA/NeMo/blob/d81beac52423dbd04b48e4e04567b17df2428e3a/examples/nlp/spellchecking_asr_customization/run_training.sh#L40 